### PR TITLE
Update README example to use `withIndex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This becomes
 
 ```elm
 viewButton context model =
-    (Button.render |> with context)
+    (Button.render |> withIndex context 0)
         [ Button.onClick Increment ]
         [ text "Add" ]
 ```


### PR DESCRIPTION
First, thank you for updating this package to work with the latest version of elm-mdl!

I just made a minor change to the README. Currently, the example uses the `with` function, but that function can't be used with `Button.render` because buttons require an index.

Looks like this is also a problem in the original repo, but I opened the pull request here because the original still isn't updated to the latest version of elm-mdl.